### PR TITLE
adding rotate to the supported css transforms

### DIFF
--- a/jquery.isotope.js
+++ b/jquery.isotope.js
@@ -171,7 +171,9 @@
         },
         scale : function ( scale ) {
           return 'scale3d(' + scale + ', ' + scale + ', 1) ';
-        }
+        },
+        rotate: function( angle ) {
+          return 'rotate3d(' + angle + ') ';
       } :
       { // 2D transform functions
         translate : function ( position ) {
@@ -179,7 +181,10 @@
         },
         scale :  function ( scale ) {
           return 'scale(' + scale + ') ';
-        }
+        },
+        rotate: function( angle ) {
+          return 'rotate(' + angle + ') ';
+		}
       }
     ,
     
@@ -206,7 +211,8 @@
       // a couple transforms we're keeping track of, we'll do it like so
       var translateFn = transformObj.translate || '',
           scaleFn = transformObj.scale || '',
-          valueFns = translateFn + scaleFn;
+          rotateFn = transformObj.rotate || '',
+          valueFns = translateFn + scaleFn + rotateFn;
 
       // set data back in elem
       $( elem ).data( 'transform', data );
@@ -279,6 +285,23 @@
   };
 
 
+  // ==================== rotate ===================
+    
+  $.cssNumber.rotate = true;
+  
+  $.cssHooks.rotate = {
+    set: function( elem, value ) {
+  
+      isoTransform.set( elem, 'rotate', value );
+  
+    },
+    
+    get: function( elem, computed ) {
+      var rotate = $.data( elem, 'rotate' );
+      return rotate && transform.rotate ? transform.rotate : '0deg';
+    }
+  };
+ 
 
 
 /*!


### PR DESCRIPTION
I used isotope in a prototype, and needed to rotate the elements outside of isotope. Unfortunately, isotope overwrote my manual setting of -moz-transform: rotate(10deg) (also, not blaming isotope completely for that, because the transform property is just a single string). So I wrote a CSS hook so isotope would at least preserve the setting!

It might be nice to separate these hooks from isotope. Adding them to the global jQuery object without telling people is slightly dangerous. One solution is to use jQuery.sub() internally.

Thanks for making a stunning plugin!
