### PR TITLE
_sort now falls back to original-order

### DIFF
--- a/jquery.isotope.js
+++ b/jquery.isotope.js
@@ -564,7 +564,13 @@
           sortFn = function( alpha, beta ) {
             var a = getSorter( alpha ),
                 b = getSorter( beta );
-            return ( ( a > b ) ? 1 : ( a < b ) ? -1 : 0 ) * sortDir;
+	        if(a==b && instance.options.sortBy != 'original-order') {
+	          a = $(alpha).data('isotope-sort-data')['original-order'];
+	          b = $(beta).data('isotope-sort-data')['original-order'];
+	          return ( ( a > b ) ? 1 : ( a < b ) ? -1 : 0 ) * sortDir;
+	        } else {
+	          return ( (a>b)?1:-1 ) * sortDir;
+	        }
           };
       
       this.$filteredAtoms.sort( sortFn );


### PR DESCRIPTION
As per one of the issues listed, when sorting elements with the same value the order can change when run multiple times. Added a small check to the _sort method that falls back to original-order and sorts by that in these cases. Not sure how much of a performance impact this has, nor whether there is a better way of writing it.
