### PR TITLE
Pass the sort key when calling sort functions

### DIFF
--- a/jquery.isotope.js
+++ b/jquery.isotope.js
@@ -518,7 +518,7 @@
             // keep original order original
             sortData[ key ] = $.data( this, 'isotope-sort-data' )[ key ];
           } else {
-            sortData[ key ] = getSortData[ key ]( $this, instance );
+            sortData[ key ] = getSortData[ key ]( $this, instance, key );
           }
         }
         // apply sort data to element


### PR DESCRIPTION
Had a case where I needed to programmatically define my sorting functions and solved it with this patch. By passing the key into the sorting functions, you can write more flexible sort functions.

Here's an example of how this could be used. Assume you've got an unkown number of pages in the pages object.  

``` javascript
var sortFunctions = {},
  sort = function( $ele, iso, key ) {
    return parseInt( $ele.find( '.' + key ).text(), 10 );
  };

for ( page in pages ) {
  sortFunctions['sort-' + pages[page].id] = sort;
}

$container.isotope( {
  getSortData: sortFunctions
} );

$( 'nav a' ).click( function() {
    var page = $( this ).data( 'page' );
    $container.isotope( { sortBy: 'sort-' + page.id } );
} );
```
