### PR TITLE
Add body class to detect how many col showing now

### DIFF
--- a/jquery.isotope.js
+++ b/jquery.isotope.js
@@ -989,6 +989,8 @@
       for ( i=0; i < setSpan; i++ ) {
         this.masonry.colYs[ shortCol + i ] = setHeight;
       }
+      
+      $("body").removeClass(function(i,c){var m=c.match(/col-(\d*)/);return m?m[0]:m}).addClass("col-"+this.masonry.cols);
 
     },
 


### PR DESCRIPTION
Add body class like how many cols showing now :

Classes look like `<body class="col-1">` = one col showing

So you can detect for CSS  if one col showing 

Ex: 

`.col-1 #grid > .item > .children   {max-width:310px;}`
`.col-2 #grid > .item > .children   {max-width:640px;}`

..... for more better control
