### PR TITLE
Multiple-attribute sorting

### DIFF
--- a/jquery.isotope.js
+++ b/jquery.isotope.js
@@ -570,29 +570,33 @@
           , sortDir = this.options.sortAscending ? 1 : -1
           , len = sortBy.length
           , sortFunc = function (a, b){              
-              a && isNaN(a) && (a = a.toLowerCase());
-              b && isNaN(b) && (b = b.toLowerCase());              
+              isNaN(a) && (a = a.toLowerCase());
+              isNaN(b) && (b = b.toLowerCase());              
               return ( a > b ) ? 1 : ( a < b ) ? -1 : 0;  
             }
           ;
+      //default an empty sort to original order
+      sortBy[0] = sortBy[0] || 'original-order';
       this.$filteredAtoms.sort(function(alpha, beta){
         var sort, comparison = 0, i = 0
             , a , b 
-            ;
-        if (sortBy[0] === 'original-order' || !(alpha && beta)) {
+        ;
+        if (sortBy[0] === 'original-order') { 
           a = getSorter(alpha, 'original-order' ); 
           b = getSorter(beta, 'original-order' );
           return sortFunc(a, b) * sortDir;
         } else {          
           while(comparison == 0 && i < len){
-            sort = sortBy[i],
-            a = getSorter(alpha, sort),
-            b = getSorter(beta, sort);            
-            comparison = sortFunc(a, b);             
+            sort = sortBy[i];
+            if (sort.length) {
+              a = getSorter(alpha, sort),
+              b = getSorter(beta, sort);            
+              comparison = sortFunc(a, b);
+            }
             i+=1;        
           }          
           return comparison * sortDir;
-        }
+        } 
       }); 
     },
 


### PR DESCRIPTION
This pull request extends the functionality of the `_sort()` method so that it can accept a comma-delimited string and sort down to a depth of n. Here's a [working demo](http://codepen.io/ultimatedelman/pen/KeEpl) that sorts down to 3 levels.

The codebase is at the top, the demo code to make it work is at the very bottom of the JS.
