### PR TITLE
Use window.getComputedStyle for fluid column widths

### DIFF
--- a/jquery.isotope.js
+++ b/jquery.isotope.js
@@ -936,7 +936,8 @@
       $elems.each(function(){
         var $this  = $(this),
             //how many columns does this brick span
-            colSpan = Math.ceil( $this.outerWidth(true) / props.columnWidth );
+            computedWidth = window.getComputedStyle(this) && parseFloat(window.getComputedStyle(this).width),
+            colSpan = Math.ceil( ( computedWidth || $this.outerWidth(true) ) / props.columnWidth );
         colSpan = Math.min( colSpan, props.cols );
 
         if ( colSpan === 1 ) {


### PR DESCRIPTION
Since `outerWidth()` rounds; addresses #222, computes number of columns with `window.getComputedStyle` and falls back to `outerWidth` (I'm not sure about the browser support for getComputedStyle)

Only tested in latest chrome, firefox
