### PR TITLE
Update isotope.js

### DIFF
--- a/js/isotope.js
+++ b/js/isotope.js
@@ -425,8 +425,7 @@ if ( typeof define === 'function' && define.amd ) {
       'outlayer/outlayer',
       'get-size/get-size',
       'matches-selector/matches-selector',
-      './item.js',
-      './layout-modes.js'
+       ['./item.js', './layout-modes.js']
     ],
     isotopeDefinition );
 } else {


### PR DESCRIPTION
Please use this notation  ['./item.js', './layout-modes.js'] to keep proper relative paths, when loading via requireJS. If not it tries to load item.js and layout-modes.js from configured baseUrl

require.config({
  baseUrl: 'js'
});

Similar issue/solution explained here http://stackoverflow.com/questions/14548369/requirejs-relative-paths/14589782#14589782
