### PR TITLE
File extensions in define: issues with requireJS

### DIFF
--- a/js/isotope.js
+++ b/js/isotope.js
@@ -425,8 +425,8 @@ if ( typeof define === 'function' && define.amd ) {
       'outlayer/outlayer',
       'get-size/get-size',
       'matches-selector/matches-selector',
-      './item.js',
-      './layout-modes.js'
+      './item',
+      './layout-modes'
     ],
     isotopeDefinition );
 } else {


### PR DESCRIPTION
After many wrong proposals (sorry for that) I realized, you've added js-extensions to define in line 428+429, which I updated. Nevertheless I've got dependency loading issues with relative paths when I load isotope v2. Could you please make an example with requireJS and perhaps configured baseUrl?
