### PR TITLE
fix: redundant CSS transitions

### DIFF
--- a/dist/isotope.pkgd.js
+++ b/dist/isotope.pkgd.js
@@ -1482,8 +1482,8 @@ Item.prototype.enableTransition = function(/* style */) {
     transitionProperty: itemTransitionProperties,
     transitionDuration: this.layout.options.transitionDuration
   });
-  // listen for transition end event
-  this.element.addEventListener( transitionEndEvent, this, false );
+  // fix: commenting out to prevent multiple transitions.
+  //this.element.addEventListener( transitionEndEvent, this, false );
 };
 
 Item.prototype.transition = Item.prototype[ transitionProperty ? '_transition' : '_nonTransition' ];


### PR DESCRIPTION
See [issue 725](https://github.com/metafizzy/isotope/issues/725).

Removing an event listener for the `transitionEndEvent` seemed to fix the issue.  The listener appears to be redundant.
