### PR TITLE
Make jQuery and jQuery Bridget dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,9 @@
     "get-size": ">=1.1.8 <1.3",
     "matches-selector": ">=1 <2",
     "outlayer": "1.3.x",
-    "masonry": "3.2.x"
+    "masonry": "3.2.x",
+    "jquery": ">=1.4.3 <2",
+    "jquery-bridget": "1.1.x"
   },
   "devDependencies": {
     "doc-ready": "1.x",
@@ -23,8 +25,6 @@
     "isotope-fit-columns": "1.x",
     "isotope-horizontal": "1.x",
     "isotope-masonry-horizontal": "1.x",
-    "jquery": ">=1.4.3 <2",
-    "jquery-bridget": "1.1.x",
     "qunit": "^1.15"
   },
   "ignore": [


### PR DESCRIPTION
I ran into issues with $.isotope being undefined and realized it is becuase the dependencies in the bower.json were only devDeps and thus weren't wired into the web app appropriately when I ran my build.

This moves the two dependencies out of dev since they are both required for proper use of the jquery plugin and are in fact included in the packaged version of the code.