### PR TITLE
Updated dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,11 +4,11 @@
   "description": "Filter and sort magical layouts",
   "main": "js/isotope.js",
   "dependencies": {
-    "get-size": "~1.2.2",
-    "matches-selector": "~1.0.2",
-    "outlayer": "~1.4.1",
-    "masonry": "~3.3.0",
-    "fizzy-ui-utils": "~1.0.1"
+    "get-size": "~2.0.2",
+    "matches-selector": "~2.0.1",
+    "outlayer": "~2.0.0",
+    "masonry": "~4.0.0",
+    "fizzy-ui-utils": "~2.0.0"
   },
   "devDependencies": {
     "doc-ready": "1.x",
@@ -18,7 +18,7 @@
     "isotope-horizontal": "1.x",
     "isotope-masonry-horizontal": "1.x",
     "jquery": ">=1.4.3 <2",
-    "jquery-bridget": "1.1.x",
+    "jquery-bridget": "2.0.0",
     "qunit": "^1.15"
   },
   "ignore": [


### PR DESCRIPTION
The new version of Masonry is now no longer including all of its files when you include it with bower. Updated the dependencies, so that Isotope is using more recent versions.