### PR TITLE
Add a filter complete event

### DIFF
--- a/dist/isotope.pkgd.js
+++ b/dist/isotope.pkgd.js
@@ -3177,6 +3177,7 @@ var trim = String.prototype.trim ?
     var matches = [];
     var hiddenMatched = [];
     var visibleUnmatched = [];
+    var results;
 
     var test = this._getFilterTest( filter );
 
@@ -3201,12 +3202,17 @@ var trim = String.prototype.trim ?
       }
     }
 
-    // return collections of items to be manipulated
-    return {
+    results = {
       matches: matches,
       needReveal: hiddenMatched,
       needHide: visibleUnmatched
     };
+
+    // allow the filtered items to be modified
+    this.dispatchEvent( 'itemsFiltered', null, [ results ] );
+
+    // return collections of items to be manipulated
+    return results;
   };
 
   // get a jQuery, function, or a matchesSelector test given the filter
@@ -3558,4 +3564,3 @@ var trim = String.prototype.trim ?
   return Isotope;
 
 }));
-

--- a/dist/isotope.pkgd.js
+++ b/dist/isotope.pkgd.js
@@ -3177,7 +3177,6 @@ var trim = String.prototype.trim ?
     var matches = [];
     var hiddenMatched = [];
     var visibleUnmatched = [];
-    var results;
 
     var test = this._getFilterTest( filter );
 
@@ -3202,17 +3201,12 @@ var trim = String.prototype.trim ?
       }
     }
 
-    results = {
+    // return collections of items to be manipulated
+    return {
       matches: matches,
       needReveal: hiddenMatched,
       needHide: visibleUnmatched
     };
-
-    // allow the filtered items to be modified
-    this.dispatchEvent( 'itemsFiltered', null, [ results ] );
-
-    // return collections of items to be manipulated
-    return results;
   };
 
   // get a jQuery, function, or a matchesSelector test given the filter
@@ -3564,3 +3558,4 @@ var trim = String.prototype.trim ?
   return Isotope;
 
 }));
+

--- a/js/isotope.js
+++ b/js/isotope.js
@@ -238,6 +238,7 @@ var trim = String.prototype.trim ?
     var matches = [];
     var hiddenMatched = [];
     var visibleUnmatched = [];
+    var results;
 
     var test = this._getFilterTest( filter );
 
@@ -262,12 +263,17 @@ var trim = String.prototype.trim ?
       }
     }
 
-    // return collections of items to be manipulated
-    return {
+    results = {
       matches: matches,
       needReveal: hiddenMatched,
       needHide: visibleUnmatched
     };
+
+    // allow the filtered items to be modified
+    this.dispatchEvent( 'itemsFiltered', null, [ results ] );
+
+    // return collections of items to be manipulated
+    return results;
   };
 
   // get a jQuery, function, or a matchesSelector test given the filter


### PR DESCRIPTION
This adds an event that fires at the end of `Isotope._filter()`. It includes the results of the call to `_filter()`, which opens up opportunities for inspecting and modifying the Items before any sorting or laying out happens.

I'm submitting this because of something I ran into on a project that uses Isotope. We have a grid of same-sized items (4 a row), then we have one wide item that spans a whole row and we needed that wide item to always show after the 12th item (or as the last item if there are fewer than 12). The grid has filter controls also, which caused us some difficulties.

In the end, I added the updated function below to a JS file in our project, and then used it to override `Isotope.prototype._filter`, hooked into the new event, and updated a "manual" sort order value on each item to make sure 12 items would always show before that wide item.

And since I'm hoping to future proof anything I do, I'm hoping that we can get this change or something similar merged in. Please let me know what you think :smiley: 